### PR TITLE
Fix background z layering

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <div id="bgLines" style="position:fixed;inset:0;z-index:0;pointer-events:none;"></div>
+  <div id="bgLines"></div>
   <nav class="navbar">
     <a href="index.html" class="logo">T</a>
     <a href="index.html">Home</a>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <div id="bgLines" style="position:fixed;inset:0;z-index:0;pointer-events:none;"></div>
+  <div id="bgLines"></div>
   <!-- Navigation bar -->
   <nav class="navbar">
     <a href="index.html" class="logo">T</a>

--- a/style.css
+++ b/style.css
@@ -239,6 +239,23 @@ body {
   }
 }
 
+/* Background Vanta container */
+#bgLines {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+}
+
 #bgLines canvas {
   opacity: 0.08 !important;
+}
+
+/* Ensure main sections render above the animated background */
+.hero,
+.stats-ribbon,
+.content,
+.projects-grid {
+  position: relative;
+  z-index: 1;
 }


### PR DESCRIPTION
## Summary
- keep Vanta background behind page content with absolute stacking rules
- move inline #bgLines styling to CSS
- ensure main sections and projects grid sit on top of the animation

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b3e1f6d2c8321847a178c08451cc7