### PR TITLE
Add Vanta Dots background

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <div id="bgLines"></div>
+  <div id="bgDots"></div>
   <nav class="navbar">
     <a href="index.html" class="logo">T</a>
     <a href="index.html">Home</a>
@@ -36,25 +36,25 @@
   </main>
   <script src="contact.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.net.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.dots.min.js"></script>
   <script>
     if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      VANTA.NET({
-        el: "#bgLines",
+      VANTA.DOTS({
+        el: "#bgDots",
         color: 0x14B8A6,
+        color2: 0x0A66C2,
         backgroundColor: 0x0F172A,
-        points: 8.0,
-        maxDistance: 20.0,
-        spacing: 18.0,
-        showDots: false,
-        gyroControls: false,
+        size: 2.0,
+        spacing: 35.0,
+        showLines: true,
         mouseControls: false,
         touchControls: false,
+        gyroControls: false,
+        minHeight: 200.0,
+        minWidth: 200.0,
         scale: 1.0,
         scaleMobile: 1.0
       });
-    } else {
-      document.querySelector('#bgLines').style.background = '#0F172A';
     }
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <div id="bgLines"></div>
+  <div id="bgDots"></div>
   <!-- Navigation bar -->
   <nav class="navbar">
     <a href="index.html" class="logo">T</a>
@@ -68,25 +68,25 @@
   </main>
   <script src="contact.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.net.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.dots.min.js"></script>
   <script>
     if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      VANTA.NET({
-        el: "#bgLines",
+      VANTA.DOTS({
+        el: "#bgDots",
         color: 0x14B8A6,
+        color2: 0x0A66C2,
         backgroundColor: 0x0F172A,
-        points: 8.0,
-        maxDistance: 20.0,
-        spacing: 18.0,
-        showDots: false,
-        gyroControls: false,
+        size: 2.0,
+        spacing: 35.0,
+        showLines: true,
         mouseControls: false,
         touchControls: false,
+        gyroControls: false,
+        minHeight: 200.0,
+        minWidth: 200.0,
         scale: 1.0,
         scaleMobile: 1.0
       });
-    } else {
-      document.querySelector('#bgLines').style.background = '#0F172A';
     }
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -240,15 +240,23 @@ body {
 }
 
 /* Background Vanta container */
-#bgLines {
+#bgDots {
   position: fixed;
   inset: 0;
   z-index: -1;
   pointer-events: none;
 }
 
-#bgLines canvas {
-  opacity: 0.08 !important;
+#bgDots::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(4px);
+}
+
+#bgDots canvas {
+  opacity: 0.06 !important;
 }
 
 /* Ensure main sections render above the animated background */


### PR DESCRIPTION
## Summary
- switch animated background from NET to DOTS
- adjust main stylesheet for bgDots overlay and fading
- keep animation behind content across pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b40f5b0688321ac0e31d58e216304